### PR TITLE
fix: Add more enun attributes to SignalProtocol

### DIFF
--- a/lib/src/sensor_signal.dart
+++ b/lib/src/sensor_signal.dart
@@ -29,6 +29,10 @@ enum SignalProtocol{
   priority,
   /// Subject of the message
   subject,
+  /// Source Sensor
+  sensor,
+  /// Source Device
+  device,
 }
 
 /// The value element of a protocol message.


### PR DESCRIPTION
This now includes the source sensor and source devices.
